### PR TITLE
Customize footer and branding for CitreaScan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ yarn-error.log*
 # build outputs
 /tools/preset-sync/index.js
 /toolkit/package/dist
+/.claude

--- a/lib/hooks/useIssueUrl.tsx
+++ b/lib/hooks/useIssueUrl.tsx
@@ -24,7 +24,7 @@ export default function useIssueUrl(backendVersion: string | undefined) {
       'frontend-version': [ config.UI.footer.frontendVersion, config.UI.footer.frontendCommit ].filter(Boolean).join('+'),
       'additional-information': `**User Agent:** ${ window.navigator.userAgent }`,
     });
-    return `https://github.com/blockscout/blockscout/issues/new/?${ searchParams.toString() }`;
+    return `https://github.com/CitreaScan/blockscout/issues/new/?${ searchParams.toString() }`;
   // we need to update link whenever page url changes
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ backendVersion, isLoading, router.asPath ]);

--- a/ui/snippets/footer/Footer.tsx
+++ b/ui/snippets/footer/Footer.tsx
@@ -9,7 +9,6 @@ import config from 'configs/app';
 import type { ResourceError } from 'lib/api/resources';
 import useApiQuery from 'lib/api/useApiQuery';
 import useFetch from 'lib/hooks/useFetch';
-import useIssueUrl from 'lib/hooks/useIssueUrl';
 import { Link } from 'toolkit/chakra/link';
 import { Skeleton } from 'toolkit/chakra/skeleton';
 import { copy } from 'toolkit/utils/htmlEntities';
@@ -35,44 +34,19 @@ const Footer = () => {
     },
   });
   const apiVersionUrl = getApiVersionUrl(backendVersionData?.backend_version);
-  const issueUrl = useIssueUrl(backendVersionData?.backend_version);
 
   const BLOCKSCOUT_LINKS = [
-    {
-      icon: 'edit' as const,
-      iconSize: '16px',
-      text: 'Submit an issue',
-      url: issueUrl,
-    },
     {
       icon: 'social/git' as const,
       iconSize: '18px',
       text: 'Contribute',
-      url: 'https://github.com/blockscout/blockscout',
+      url: 'https://github.com/CitreaScan/blockscout',
     },
     {
       icon: 'social/twitter' as const,
       iconSize: '18px',
-      text: 'X (ex-Twitter)',
-      url: 'https://x.com/blockscout',
-    },
-    {
-      icon: 'social/discord' as const,
-      iconSize: '24px',
-      text: 'Discord',
-      url: 'https://discord.gg/blockscout',
-    },
-    {
-      icon: 'brands/blockscout' as const,
-      iconSize: '18px',
-      text: 'All chains',
-      url: 'https://www.blockscout.com/chains-and-projects',
-    },
-    {
-      icon: 'donate' as const,
-      iconSize: '20px',
-      text: 'Donate',
-      url: 'https://eth.blockscout.com/address/0xfB4aF6A8592041E9BcE186E5aC4BDbd2B137aD11',
+      text: 'X.com',
+      url: 'https://x.com/CitreaScan',
     },
   ];
 
@@ -132,7 +106,7 @@ const Footer = () => {
           </Link>
         </Flex>
         <Text mt={ 3 } fontSize="xs">
-          Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for Ethereum Networks.
+          Blockscout is a tool for inspecting and analyzing EVM based blockchains.
         </Text>
         <Box mt={ 6 } alignItems="start" textStyle="xs">
           { apiVersionUrl && (
@@ -247,15 +221,15 @@ const Footer = () => {
           gap={ 1 }
           gridTemplateColumns={{
             base: 'repeat(auto-fill, 160px)',
-            lg: 'repeat(2, 160px)',
-            xl: 'repeat(3, 160px)',
+            lg: 'repeat(1, 160px)',
+            xl: 'repeat(1, 160px)',
           }}
           gridTemplateRows={{
             base: 'auto',
-            lg: 'repeat(3, auto)',
-            xl: 'repeat(2, auto)',
+            lg: 'auto',
+            xl: 'auto',
           }}
-          gridAutoFlow={{ base: 'row', lg: 'column' }}
+          gridAutoFlow={{ base: 'row', lg: 'row' }}
           alignContent="start"
           justifyContent={{ lg: 'flex-end' }}
           mt={{ base: 8, lg: 0 }}

--- a/ui/snippets/footer/utils/getApiVersionUrl.tsx
+++ b/ui/snippets/footer/utils/getApiVersionUrl.tsx
@@ -6,8 +6,8 @@ export default function getApiVersionUrl(version: string | undefined): string | 
   const [ tag, commit ] = version.split('.+commit.');
 
   if (commit) {
-    return `https://github.com/blockscout/blockscout/commit/${ commit }`;
+    return `https://github.com/CitreaScan/blockscout/commit/${ commit }`;
   }
 
-  return `https://github.com/blockscout/blockscout/tree/${ tag }`;
+  return `https://github.com/CitreaScan/blockscout/tree/${ tag }`;
 }


### PR DESCRIPTION
## Summary
- Update GitHub URLs to CitreaScan organization
- Remove Ethereum Networks reference from footer description
- Simplify footer links (remove Submit Issue, Discord, All Chains, Donate)
- Update X/Twitter link and text to CitreaScan
- Adjust footer layout for streamlined link display
- Add .claude to .gitignore
- Remove unused useIssueUrl import

## Changes
- Updated all GitHub repository URLs from blockscout/blockscout to CitreaScan/blockscout
- Removed "Blockchain explorer for Ethereum Networks" text from footer
- Cleaned up footer social links to only include Contribute and X.com
- Updated Twitter/X link to point to @CitreaScan
- Simplified footer grid layout for better alignment

## Test plan
- [x] Verify footer displays correctly on localhost:3000
- [x] Check that all links point to correct CitreaScan URLs
- [x] Ensure no ESLint errors
- [x] Confirm layout adjustments work on desktop view