### PR TITLE
Fix USD price formatting to 2 decimal places

### DIFF
--- a/ui/tx/details/TxDetailsBurntFees.tsx
+++ b/ui/tx/details/TxDetailsBurntFees.tsx
@@ -50,6 +50,7 @@ const TxDetailsBurntFees = ({ data, isLoading }: Props) => {
           flexWrap="wrap"
           rowGap={ 0 }
           isLoading={ isLoading }
+          accuracyUsd={ 2 }
         />
       </DetailedInfo.ItemValue>
     </>

--- a/ui/tx/details/TxDetailsSetMaxGasLimit.tsx
+++ b/ui/tx/details/TxDetailsSetMaxGasLimit.tsx
@@ -37,6 +37,7 @@ const TxDetailsSetMaxGasLimit = ({ data }: Props) => {
           flexWrap="wrap"
           mr={ 3 }
           rowGap={ 0 }
+          accuracyUsd={ 2 }
         />
       </DetailedInfo.ItemValue>
       <TxDetailsGasUsage data={ data }/>

--- a/ui/tx/details/TxDetailsTxFee.tsx
+++ b/ui/tx/details/TxDetailsTxFee.tsx
@@ -29,6 +29,7 @@ const TxDetailsTxFee = ({ isLoading, data }: Props) => {
           isLoading={ isLoading }
           withUsd
           rowGap={ 0 }
+          accuracyUsd={ 2 }
         />
       );
     }
@@ -47,6 +48,7 @@ const TxDetailsTxFee = ({ isLoading, data }: Props) => {
           flexWrap="wrap"
           mr={ 3 }
           rowGap={ 0 }
+          accuracyUsd={ 2 }
         />
         <DetailedInfoItemBreakdown.Container loading={ isLoading }>
           <DetailedInfoItemBreakdown.Row
@@ -61,6 +63,7 @@ const TxDetailsTxFee = ({ isLoading, data }: Props) => {
               showGweiTooltip
               flexWrap="wrap"
               rowGap={ 0 }
+              accuracyUsd={ 2 }
             />
           </DetailedInfoItemBreakdown.Row>
           <DetailedInfoItemBreakdown.Row
@@ -75,6 +78,7 @@ const TxDetailsTxFee = ({ isLoading, data }: Props) => {
               showGweiTooltip
               flexWrap="wrap"
               rowGap={ 0 }
+              accuracyUsd={ 2 }
             />
           </DetailedInfoItemBreakdown.Row>
         </DetailedInfoItemBreakdown.Container>

--- a/ui/tx/details/TxInfo.tsx
+++ b/ui/tx/details/TxInfo.tsx
@@ -620,6 +620,7 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
               exchangeRate={ data.exchange_rate }
               isLoading={ isLoading }
               flexWrap="wrap"
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>
@@ -640,6 +641,7 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
               currency={ currencyUnits.ether }
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>
@@ -660,6 +662,7 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
               isLoading={ isLoading }
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
 
@@ -676,6 +679,7 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
               isLoading={ isLoading }
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>

--- a/ui/tx/details/TxInfoScrollFees.tsx
+++ b/ui/tx/details/TxInfoScrollFees.tsx
@@ -34,6 +34,7 @@ export const TxInfoScrollFees = ({ data, isLoading }: Props) => {
               currency={ currencyUnits.ether }
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>
@@ -53,6 +54,7 @@ export const TxInfoScrollFees = ({ data, isLoading }: Props) => {
               currency={ currencyUnits.ether }
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>
@@ -72,6 +74,7 @@ export const TxInfoScrollFees = ({ data, isLoading }: Props) => {
               currency={ currencyUnits.ether }
               exchangeRate={ data.exchange_rate }
               flexWrap="wrap"
+              accuracyUsd={ 2 }
             />
           </DetailedInfo.ItemValue>
         </>
@@ -92,6 +95,7 @@ export const TxInfoScrollFees = ({ data, isLoading }: Props) => {
                 currency={ currencyUnits.ether }
                 exchangeRate={ data.exchange_rate }
                 flexWrap="wrap"
+                accuracyUsd={ 2 }
               />
             </Skeleton>
           </DetailedInfo.ItemValue>


### PR DESCRIPTION
## Summary
Fixes USD price display in transaction details by rounding to 2 decimal places for improved readability.

## Problem
USD prices were displayed with excessive precision, making them hard to read:
- Before: `($1.514299342319406762)`
- Before: `($0.187069587177165)`

## Solution
Added `accuracyUsd={2}` parameter to all `CurrencyValue` components in transaction details pages to limit USD amounts to 2 decimal places while maintaining full precision for native currency values.

## Changes
Applied USD formatting to all transaction detail fields:
- Transaction value
- Transaction fees (total, base fee, priority fee)
- Burnt fees
- Operator fees (Optimistic rollups)
- Poster/Network fees (Arbitrum)
- Scroll L1/L2 fees
- Max gas limit display

## Result
- After: `($1.51)`
- After: `($0.19)`

All USD amounts now display in clean `$X.XX` format.

## Testing
Tested locally on transaction detail page with various fee types - all USD values now properly rounded to 2 decimal places.