### PR TITLE
Fix contradictory transaction status display

### DIFF
--- a/ui/tx/details/TxInfo.tsx
+++ b/ui/tx/details/TxInfo.tsx
@@ -312,20 +312,22 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
       <DetailedInfo.ItemValue multiRow={ Boolean(data.scroll?.l2_block_status) }>
         { data.block_number === null ?
           <Text>Pending</Text> : (
-            <BlockEntity
-              isLoading={ isLoading }
-              number={ data.block_number }
-              noIcon
-            />
+            <>
+              <BlockEntity
+                isLoading={ isLoading }
+                number={ data.block_number }
+                noIcon
+              />
+              { Boolean(data.confirmations) && (
+                <>
+                  <TextSeparator/>
+                  <Skeleton loading={ isLoading } color="text.secondary">
+                    <span>{ data.confirmations } Block confirmations</span>
+                  </Skeleton>
+                </>
+              ) }
+            </>
           ) }
-        { Boolean(data.confirmations) && (
-          <>
-            <TextSeparator/>
-            <Skeleton loading={ isLoading } color="text.secondary">
-              <span>{ data.confirmations } Block confirmations</span>
-            </Skeleton>
-          </>
-        ) }
         { data.scroll?.l2_block_status && (
           <>
             <TextSeparator/>


### PR DESCRIPTION
## Summary
Fixed a bug where transactions displayed contradictory status information, showing both "Pending" and block confirmations simultaneously.

## Changes
- Modified `ui/tx/details/TxInfo.tsx` to only display block confirmations when `block_number !== null`
- Moved confirmations rendering inside the block entity conditional branch

## Before
Transactions could show: `Block: Pending | 1 Block confirmations` ❌

## After
- Pending transactions show: `Block: Pending` ✅
- Confirmed transactions show: `Block: #123 | 1 Block confirmations` ✅

## Technical Details
The bug occurred because the "Pending" text and confirmations count were rendered based on separate, independent conditions. This fix ensures they are mutually exclusive by only rendering confirmations when a block number exists.