### PR TITLE
Update .env.prd to mainnet configuration

### DIFF
--- a/.env.prd
+++ b/.env.prd
@@ -2,17 +2,17 @@
 # These are the production-specific settings that will NOT be blacklisted by entrypoint.sh
 
 # App ENVs
-NEXT_PUBLIC_APP_HOST=testnet.citreascan.com
+NEXT_PUBLIC_APP_HOST=citreascan.com
 NEXT_PUBLIC_APP_PROTOCOL=https
 
 # Instance ENVs
-NEXT_PUBLIC_API_HOST=testnet.citreascan.com
+NEXT_PUBLIC_API_HOST=citreascan.com
 NEXT_PUBLIC_API_PROTOCOL=https
 
-NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.testnet.citreascan.com
-NEXT_PUBLIC_NETWORK_NAME=Citrea Testnet
-NEXT_PUBLIC_NETWORK_SHORT_NAME=Citrea Testnet
-NEXT_PUBLIC_NETWORK_ID=5115
+NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.citreascan.com
+NEXT_PUBLIC_NETWORK_NAME=Citrea Mainnet
+NEXT_PUBLIC_NETWORK_SHORT_NAME=Citrea Mainnet
+NEXT_PUBLIC_NETWORK_ID=4114
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=Citrea
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=cBTC
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18


### PR DESCRIPTION
## Summary
- Switch production environment from testnet to mainnet configuration
- Update app and API host from testnet.citreascan.com to citreascan.com
- Change network RPC URL, name, and ID to mainnet values (ID: 4114)

## Test plan
- [ ] Verify environment variables are correctly applied in production build
- [ ] Confirm mainnet RPC connectivity
- [ ] Test that the application loads with mainnet data