### PR TITLE
feat(ui): display internal transaction values in address transactions

### DIFF
--- a/types/api/transaction.ts
+++ b/types/api/transaction.ts
@@ -112,6 +112,11 @@ export type Transaction = {
   authorization_list?: Array<TxAuthorization>;
   // Interop
   op_interop_messages?: Array<InteropTransactionInfo>;
+  // Internal transaction value flow (for address page transactions)
+  internal_value_flow?: {
+    'in': string;
+    out: string;
+  };
 };
 
 type ArbitrumTransactionData = {

--- a/ui/txs/TxsTableItem.tsx
+++ b/ui/txs/TxsTableItem.tsx
@@ -1,4 +1,5 @@
 import { Flex, VStack } from '@chakra-ui/react';
+import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import type { Transaction } from 'types/api/transaction';
@@ -7,12 +8,14 @@ import type { ChainConfig } from 'types/multichain';
 import config from 'configs/app';
 import { Badge } from 'toolkit/chakra/badge';
 import { TableCell, TableRow } from 'toolkit/chakra/table';
+import { Tooltip } from 'toolkit/chakra/tooltip';
 import ChainIcon from 'ui/optimismSuperchain/components/ChainIcon';
 import AddressFromTo from 'ui/shared/address/AddressFromTo';
 import BlockPendingUpdateHint from 'ui/shared/block/BlockPendingUpdateHint';
 import CurrencyValue from 'ui/shared/CurrencyValue';
 import BlockEntity from 'ui/shared/entities/block/BlockEntity';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import IconSvg from 'ui/shared/IconSvg';
 import TxStatus from 'ui/shared/statusTag/TxStatus';
 import TimeWithTooltip from 'ui/shared/time/TimeWithTooltip';
 import TxFee from 'ui/shared/tx/TxFee';
@@ -34,6 +37,16 @@ type Props = {
 
 const TxsTableItem = ({ tx, showBlockInfo, currentAddress, enableTimeIncrement, isLoading, animation, chainData }: Props) => {
   const dataTo = tx.to ? tx.to : tx.created_contract;
+
+  // Calculate display value: use internal_value_flow if tx.value is 0
+  const txValue = new BigNumber(tx.value);
+  const hasInternalValueFlow = tx.internal_value_flow &&
+    (tx.internal_value_flow.in !== '0' || tx.internal_value_flow.out !== '0');
+  const internalValueIn = hasInternalValueFlow ? new BigNumber(tx.internal_value_flow?.in || '0') : new BigNumber(0);
+
+  // Show internal value when tx.value is 0 and there's internal flow
+  const showInternalValue = txValue.isZero() && hasInternalValueFlow && internalValueIn.gt(0);
+  const displayValue = showInternalValue ? tx.internal_value_flow?.in || '0' : tx.value;
 
   return (
     <TableRow key={ tx.hash } animation={ animation }>
@@ -113,7 +126,14 @@ const TxsTableItem = ({ tx, showBlockInfo, currentAddress, enableTimeIncrement, 
       </TableCell>
       { !config.UI.views.tx.hiddenFields?.value && (
         <TableCell isNumeric>
-          <CurrencyValue value={ tx.value } accuracy={ 8 } isLoading={ isLoading } wordBreak="break-word"/>
+          <Flex alignItems="center" justifyContent="flex-end" gap={ 1 }>
+            { showInternalValue && (
+              <Tooltip content="Value from internal transaction">
+                <IconSvg name="internal_txns" boxSize={ 4 } color="text.secondary" flexShrink={ 0 }/>
+              </Tooltip>
+            ) }
+            <CurrencyValue value={ displayValue } accuracy={ 8 } isLoading={ isLoading } wordBreak="break-word"/>
+          </Flex>
         </TableCell>
       ) }
       { !config.UI.views.tx.hiddenFields?.tx_fee && (


### PR DESCRIPTION
## Summary

- Display internal transaction values when `tx.value` is 0 but internal transactions moved funds
- Adds visual indicator (internal_txns icon with tooltip) to distinguish from direct transfers
- Common use cases: claim, lock, refund operations on smart contracts

## Changes

### `types/api/transaction.ts`
- Added `internal_value_flow?: { in: string; out: string }` to Transaction type

### `ui/txs/TxsTableItem.tsx`
- Calculate display value based on `tx.value` and `internal_value_flow`
- Show internal_txns icon with tooltip when displaying internal value

### `ui/txs/TxsListItem.tsx`
- Same logic for mobile view

## Dependencies

Requires backend PR: https://github.com/CitreaScan/blockscout/pull/15

## Test plan

- [x] View address transactions page for an address with claim/lock/refund transactions
- [x] Verify internal value is displayed instead of 0
- [x] Verify internal_txns icon appears with tooltip
- [ ] Test mobile view (TxsListItem)