### PR TITLE
develop to main

### DIFF
--- a/lib/token/useLaunchpadTokenImage.ts
+++ b/lib/token/useLaunchpadTokenImage.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+
+import config from 'configs/app';
+
+// Supported chain IDs for launchpad
+const SUPPORTED_CHAIN_IDS = [ '4114', '5115' ];
+
+interface LaunchpadTokenData {
+  imageUrl: string | null;
+  launchpadUrl: string | null;
+}
+
+async function fetchLaunchpadTokenData(tokenAddress: string, chainId: string): Promise<LaunchpadTokenData> {
+  const response = await fetch(`/api/launchpad-token?address=${ tokenAddress.toLowerCase() }&chainId=${ chainId }`);
+
+  if (!response.ok) {
+    return { imageUrl: null, launchpadUrl: null };
+  }
+
+  return response.json() as Promise<LaunchpadTokenData>;
+}
+
+/**
+ * Hook to fetch launchpad token data from JuiceSwap
+ * Use this as a fallback when a token doesn't have an icon_url
+ *
+ * @param tokenAddress - The token contract address
+ * @param enabled - Whether to enable the query (e.g., only when icon_url is missing)
+ * @returns Query result with { imageUrl, launchpadUrl }
+ */
+export function useLaunchpadTokenImage(tokenAddress: string | undefined, enabled: boolean = true) {
+  const chainId = String(config.chain.id);
+  const isSupported = SUPPORTED_CHAIN_IDS.includes(chainId);
+
+  return useQuery({
+    queryKey: [ 'launchpad-token-data', chainId, tokenAddress?.toLowerCase() ],
+    queryFn: () => fetchLaunchpadTokenData(tokenAddress ?? '', chainId),
+    staleTime: 24 * 60 * 60 * 1000, // 24 hours (metadata is immutable)
+    gcTime: 24 * 60 * 60 * 1000,
+    enabled: enabled && isSupported && Boolean(tokenAddress),
+    retry: 2,
+  });
+}

--- a/pages/api/launchpad-token.ts
+++ b/pages/api/launchpad-token.ts
@@ -1,0 +1,103 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// JuiceSwap Ponder API URLs by chain ID
+const PONDER_API_URLS: Record<string, string> = {
+  '4114': 'https://ponder.juiceswap.com',
+  '5115': 'https://dev.ponder.juiceswap.com',
+};
+
+// JuiceSwap Launchpad URLs by chain ID
+const LAUNCHPAD_URLS: Record<string, string> = {
+  '4114': 'https://bapp.juiceswap.com/launchpad',
+  '5115': 'https://dev.bapp.juiceswap.com/launchpad',
+};
+
+interface LaunchpadTokenResponse {
+  token?: {
+    metadataURI?: string | null;
+  };
+}
+
+interface TokenMetadata {
+  name?: string;
+  description?: string;
+  image?: string;
+  external_url?: string;
+}
+
+interface LaunchpadTokenData {
+  imageUrl: string | null;
+  launchpadUrl: string | null;
+}
+
+function ipfsToHttp(uri: string): string {
+  if (uri.startsWith('ipfs://')) {
+    return uri.replace('ipfs://', 'https://gateway.pinata.cloud/ipfs/');
+  }
+  if (uri.startsWith('ar://')) {
+    return uri.replace('ar://', 'https://arweave.net/');
+  }
+  return uri;
+}
+
+const handler = async(req: NextApiRequest, res: NextApiResponse<LaunchpadTokenData | { error: string }>) => {
+  const { address, chainId } = req.query;
+
+  if (!address || typeof address !== 'string') {
+    return res.status(400).json({ error: 'Missing address parameter' });
+  }
+
+  if (!chainId || typeof chainId !== 'string') {
+    return res.status(400).json({ error: 'Missing chainId parameter' });
+  }
+
+  const ponderUrl = PONDER_API_URLS[chainId];
+  const launchpadBaseUrl = LAUNCHPAD_URLS[chainId];
+
+  if (!ponderUrl) {
+    return res.status(200).json({ imageUrl: null, launchpadUrl: null });
+  }
+
+  try {
+    // Step 1: Get metadataURI from Ponder API
+    const ponderResponse = await fetch(`${ ponderUrl }/launchpad/token/${ address.toLowerCase() }`);
+
+    if (!ponderResponse.ok) {
+      if (ponderResponse.status === 404 || ponderResponse.status === 503) {
+        return res.status(200).json({ imageUrl: null, launchpadUrl: null });
+      }
+      return res.status(ponderResponse.status).json({ error: `Ponder API error: ${ ponderResponse.status }` });
+    }
+
+    const ponderData = await ponderResponse.json() as LaunchpadTokenResponse;
+
+    if (!ponderData.token?.metadataURI) {
+      return res.status(200).json({ imageUrl: null, launchpadUrl: null });
+    }
+
+    const launchpadUrl = launchpadBaseUrl ? `${ launchpadBaseUrl }/${ address }` : null;
+
+    // Step 2: Fetch metadata from IPFS
+    const metadataUrl = ipfsToHttp(ponderData.token.metadataURI);
+    const metadataResponse = await fetch(metadataUrl);
+
+    if (!metadataResponse.ok) {
+      return res.status(200).json({ imageUrl: null, launchpadUrl });
+    }
+
+    const metadata = await metadataResponse.json() as TokenMetadata;
+
+    if (!metadata.image) {
+      return res.status(200).json({ imageUrl: null, launchpadUrl });
+    }
+
+    // Step 3: Convert image URI to HTTP URL
+    const imageUrl = ipfsToHttp(metadata.image);
+
+    return res.status(200).json({ imageUrl, launchpadUrl });
+  } catch {
+    return res.status(500).json({ error: 'Failed to fetch launchpad token data' });
+  }
+};
+
+export default handler;

--- a/ui/token/TokenPageTitle.tsx
+++ b/ui/token/TokenPageTitle.tsx
@@ -12,6 +12,8 @@ import type { ResourceError } from 'lib/api/resources';
 import useApiQuery from 'lib/api/useApiQuery';
 import { useMultichainContext } from 'lib/contexts/multichain';
 import { getTokenTypeName } from 'lib/token/tokenTypes';
+import { useLaunchpadTokenImage } from 'lib/token/useLaunchpadTokenImage';
+import { Link } from 'toolkit/chakra/link';
 import { Tooltip } from 'toolkit/chakra/tooltip';
 import AddressAlerts from 'ui/address/details/AddressAlerts';
 import AddressQrCode from 'ui/address/details/AddressQrCode';
@@ -44,6 +46,27 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, hash }: Props) => {
     pathParams: { hash: addressHash, chainId: config.chain.id },
     queryOptions: { enabled: Boolean(tokenQuery.data) && !tokenQuery.isPlaceholderData && config.features.verifiedTokens.isEnabled },
   });
+
+  // Fetch launchpad token data - always fetch, we'll use it only if no icon_url
+  const launchpadQuery = useLaunchpadTokenImage(hash);
+  const launchpadData = launchpadQuery.data;
+
+  // Token with launchpad image fallback
+  const tokenWithImage = React.useMemo(() => {
+    if (!tokenQuery.data) {
+      return undefined;
+    }
+    if (tokenQuery.data.icon_url) {
+      return tokenQuery.data;
+    }
+    if (launchpadData?.imageUrl) {
+      return {
+        ...tokenQuery.data,
+        icon_url: launchpadData.imageUrl,
+      };
+    }
+    return tokenQuery.data;
+  }, [ tokenQuery.data, launchpadData?.imageUrl ]);
 
   const addressesForMetadataQuery = React.useMemo(() => ([ hash ].filter(Boolean)), [ hash ]);
   const addressMetadataQuery = useAddressMetadataInfoQuery(addressesForMetadataQuery);
@@ -119,7 +142,7 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, hash }: Props) => {
           } : undefined }
         />
       ) }
-      { !isLoading && tokenQuery.data && <AddressAddToWallet token={ tokenQuery.data } variant="button"/> }
+      { !isLoading && tokenWithImage && <AddressAddToWallet token={ tokenWithImage } variant="button"/> }
       { addressQuery.data && <AddressQrCode hash={ addressQuery.data.hash } isLoading={ isLoading }/> }
       <AccountActionsMenu isLoading={ isLoading }/>
       <Flex ml={{ base: 0, lg: 'auto' }} columnGap={ 2 } flexGrow={{ base: 1, lg: 0 }}>
@@ -129,19 +152,38 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, hash }: Props) => {
     </Flex>
   );
 
+  const tokenIconElement = React.useMemo(() => {
+    if (!tokenWithImage) {
+      return null;
+    }
+
+    const icon = (
+      <TokenEntity.Icon
+        token={ tokenWithImage }
+        isLoading={ tokenQuery.isPlaceholderData }
+        variant="heading"
+        chain={ multichainContext?.chain }
+      />
+    );
+
+    // Only show link if we're using the launchpad image (token has no own icon_url)
+    if (launchpadData?.launchpadUrl && !tokenQuery.data?.icon_url) {
+      return (
+        <Link href={ launchpadData.launchpadUrl } target="_blank" rel="noopener noreferrer">
+          { icon }
+        </Link>
+      );
+    }
+
+    return icon;
+  }, [ tokenWithImage, tokenQuery.data?.icon_url, tokenQuery.isPlaceholderData, multichainContext?.chain, launchpadData?.launchpadUrl ]);
+
   return (
     <>
       <PageTitle
         title={ `${ tokenQuery.data?.name || 'Unnamed token' }${ tokenSymbolText }` }
         isLoading={ tokenQuery.isPlaceholderData }
-        beforeTitle={ tokenQuery.data ? (
-          <TokenEntity.Icon
-            token={ tokenQuery.data }
-            isLoading={ tokenQuery.isPlaceholderData }
-            variant="heading"
-            chain={ multichainContext?.chain }
-          />
-        ) : null }
+        beforeTitle={ tokenIconElement }
         contentAfter={ contentAfter }
         secondRow={ secondRow }
       />


### PR DESCRIPTION
* feat(token): add JuiceSwap launchpad token image fallback

When a token doesn't have an icon_url, fetch the image from JuiceSwap Launchpad via their Ponder API. The token icon becomes clickable and links to the JuiceSwap Launchpad page.

- Add API proxy at /api/launchpad-token to bypass CORS
- Add useLaunchpadTokenImage hook for fetching launchpad data
- Update TokenPageTitle to use launchpad image as fallback
- Support Citrea Mainnet (4114) and Testnet (5115)

* fix: only show launchpad link when using launchpad image

## Description and Related Issue(s)

*[Provide a brief description of the changes or enhancements introduced by this pull request and explain motivation behind them. Cite any related issue(s) or bug(s) that it addresses using the [format](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/) `Fixes #123` or `Resolves #456`.]*

### Proposed Changes
*[Specify the changes or additions made in this pull request. Please mention if any changes were made to the ENV variables]*

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
