### PR TITLE
feat(ui): replace Spinner with CitreaSpinner in core components

### DIFF
--- a/toolkit/chakra/toaster.tsx
+++ b/toolkit/chakra/toaster.tsx
@@ -3,11 +3,12 @@
 import {
   Toaster as ChakraToaster,
   Portal,
-  Spinner,
   Stack,
   Toast,
   createToaster,
 } from '@chakra-ui/react';
+
+import CitreaSpinner from 'ui/shared/CitreaSpinner';
 
 import { SECOND } from '../utils/consts';
 import { CloseButton } from './close-button';
@@ -34,7 +35,7 @@ export const Toaster = () => {
           return (
             <Toast.Root width={{ md: 'sm' }}>
               { toast.type === 'loading' ? (
-                <Spinner size="sm" color="orange.500" my={ 1 }/>
+                <CitreaSpinner size={ 20 } my={ 1 } flexShrink={ 0 }/>
               ) : null }
               <Stack gap="0" flex="1" maxWidth="100%">
                 { toast.title && <Toast.Title>{ toast.title }</Toast.Title> }

--- a/ui/operation/tac/TacOperationLifecycleAccordionItemTrigger.tsx
+++ b/ui/operation/tac/TacOperationLifecycleAccordionItemTrigger.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, Spinner } from '@chakra-ui/react';
+import { Box, HStack } from '@chakra-ui/react';
 import React from 'react';
 
 import type * as tac from '@blockscout/tac-operation-lifecycle-types';
@@ -6,6 +6,7 @@ import type * as tac from '@blockscout/tac-operation-lifecycle-types';
 import { STATUS_LABELS } from 'lib/operations/tac';
 import { AccordionItemTrigger } from 'toolkit/chakra/accordion';
 import { Skeleton } from 'toolkit/chakra/skeleton';
+import CitreaSpinner from 'ui/shared/CitreaSpinner';
 import IconSvg from 'ui/shared/IconSvg';
 
 interface Props {
@@ -23,7 +24,7 @@ const TacOperationLifecycleAccordionItemTrigger = ({ status, isFirst, isLast, is
       case 'pending': {
         return (
           <HStack gap={ 2 }>
-            <Spinner size="md"/>
+            <CitreaSpinner size={ 24 } flexShrink={ 0 }/>
             <Box color="text.secondary">
               Pending
             </Box>

--- a/ui/optimismSuperchain/crossChainTxs/CrossChainTxsTableItem.tsx
+++ b/ui/optimismSuperchain/crossChainTxs/CrossChainTxsTableItem.tsx
@@ -1,4 +1,4 @@
-import { Spinner, VStack } from '@chakra-ui/react';
+import { VStack } from '@chakra-ui/react';
 import React from 'react';
 
 import type * as multichain from '@blockscout/multichain-aggregator-types';
@@ -14,6 +14,7 @@ import { Skeleton } from 'toolkit/chakra/skeleton';
 import { TableCell, TableRow } from 'toolkit/chakra/table';
 import CrossChainTxStatusTag from 'ui/optimismSuperchain/components/CrossChainTxStatusTag';
 import AddressFromTo from 'ui/shared/address/AddressFromTo';
+import CitreaSpinner from 'ui/shared/CitreaSpinner';
 import TokenEntity from 'ui/shared/entities/token/TokenEntity';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
 import TimeWithTooltip from 'ui/shared/time/TimeWithTooltip';
@@ -79,7 +80,7 @@ const CrossChainTxsTableItem = ({ item, isLoading, animation, currencySymbol, cu
             minH="30px"
           />
         ) :
-          <Spinner size="md" my="5px"/>
+          <CitreaSpinner size={ 24 } my="5px" flexShrink={ 0 }/>
         }
       </TableCell>
       <TableCell>
@@ -92,7 +93,7 @@ const CrossChainTxsTableItem = ({ item, isLoading, animation, currencySymbol, cu
             minH="30px"
           />
         ) :
-          <Spinner size="md" my="5px"/>
+          <CitreaSpinner size={ 24 } my="5px" flexShrink={ 0 }/>
         }
       </TableCell>
       <TableCell>

--- a/ui/shared/CitreaSpinner.tsx
+++ b/ui/shared/CitreaSpinner.tsx
@@ -1,19 +1,23 @@
+import { Box } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
 import Lottie from 'lottie-react';
 import React from 'react';
 
 import spinnerAnimation from './citrea-spinner.json';
 
-interface Props {
+interface Props extends BoxProps {
   size?: number;
 }
 
-const CitreaSpinner = ({ size = 24 }: Props) => {
+const CitreaSpinner = ({ size = 24, ...props }: Props) => {
   return (
-    <Lottie
-      animationData={ spinnerAnimation }
-      loop={ true }
-      style={{ width: size, height: size }}
-    />
+    <Box display="inline-block" { ...props }>
+      <Lottie
+        animationData={ spinnerAnimation }
+        loop={ true }
+        style={{ width: size, height: size }}
+      />
+    </Box>
   );
 };
 

--- a/ui/shared/entities/operation/OperationEntity.tsx
+++ b/ui/shared/entities/operation/OperationEntity.tsx
@@ -1,10 +1,11 @@
-import { Spinner, chakra } from '@chakra-ui/react';
+import { chakra } from '@chakra-ui/react';
 import React from 'react';
 
 import * as tac from '@blockscout/tac-operation-lifecycle-types';
 
 import { route } from 'nextjs-routes';
 
+import CitreaSpinner from 'ui/shared/CitreaSpinner';
 import * as EntityBase from 'ui/shared/entities/base/components';
 
 import { distributeEntityProps } from '../base/utils';
@@ -29,7 +30,7 @@ type IconProps = EntityBase.IconBaseProps & Pick<EntityProps, 'type'>;
 const Icon = (props: IconProps) => {
   switch (props.type) {
     case tac.OperationType.PENDING: {
-      return <Spinner size="md" marginRight={ props.marginRight ?? '8px' }/>;
+      return <CitreaSpinner size={ 24 } marginRight={ props.marginRight ?? '8px' } flexShrink={ 0 }/>;
     }
     default: {
       return (

--- a/ui/tx/TxPendingAlert.tsx
+++ b/ui/tx/TxPendingAlert.tsx
@@ -1,11 +1,11 @@
-import { Spinner } from '@chakra-ui/react';
 import React from 'react';
 
 import { Alert } from 'toolkit/chakra/alert';
+import CitreaSpinner from 'ui/shared/CitreaSpinner';
 
 const TxPendingAlert = () => {
   return (
-    <Alert startElement={ <Spinner size="sm" my={ 1 }/> }>
+    <Alert startElement={ <CitreaSpinner size={ 20 } my={ 1 } flexShrink={ 0 }/> }>
       This transaction is pending confirmation.
     </Alert>
   );


### PR DESCRIPTION
## Summary
Replace generic Chakra UI `Spinner` with `CitreaSpinner` in high/medium priority locations

## Changes
- Extended `CitreaSpinner` to accept Chakra `BoxProps` for cleaner usage
- Replaced spinners in:
  - `TxPendingAlert` (high priority)
  - Toast notifications (medium priority)
  - `OperationEntity` pending state (medium priority)
  - Cross-chain TX table (2 locations, medium priority)
  - TAC operation lifecycle (medium priority)

Closes #35