### PR TITLE
fix: display total transaction fee including L1 data fee

### DIFF
--- a/lib/web3/useCitreaL1Fee.ts
+++ b/lib/web3/useCitreaL1Fee.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
+import type { Hash } from 'viem';
+
+import { publicClient } from './client';
+
+interface CitreaTransactionReceipt {
+  l1DiffSize?: string;
+  l1FeeRate?: string;
+}
+
+interface CitreaL1FeeResult {
+  l1Fee: string | null;
+  l1DiffSize: string | null;
+  l1FeeRate: string | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+async function fetchCitreaL1Fee(hash: Hash): Promise<{ l1Fee: string; l1DiffSize: string; l1FeeRate: string } | null> {
+  if (!publicClient) {
+    return null;
+  }
+
+  const receipt = await publicClient.request({
+    method: 'eth_getTransactionReceipt' as 'eth_getTransactionReceipt',
+    params: [ hash ],
+  }) as CitreaTransactionReceipt | null;
+
+  if (!receipt || !receipt.l1DiffSize || !receipt.l1FeeRate) {
+    return null;
+  }
+
+  // Parse hex values (e.g., "0x34" -> 52)
+  const l1DiffSize = BigNumber(receipt.l1DiffSize.replace('0x', ''), 16);
+  const l1FeeRate = BigNumber(receipt.l1FeeRate.replace('0x', ''), 16);
+  const l1Fee = l1DiffSize.multipliedBy(l1FeeRate);
+
+  return {
+    l1Fee: l1Fee.toString(),
+    l1DiffSize: l1DiffSize.toString(),
+    l1FeeRate: l1FeeRate.toString(),
+  };
+}
+
+export default function useCitreaL1Fee(hash: Hash | undefined): CitreaL1FeeResult {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [ 'citrea-l1-fee', hash ],
+    queryFn: () => fetchCitreaL1Fee(hash!),
+    enabled: Boolean(hash && publicClient),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    l1Fee: data?.l1Fee ?? null,
+    l1DiffSize: data?.l1DiffSize ?? null,
+    l1FeeRate: data?.l1FeeRate ?? null,
+    isLoading,
+    error: error as Error | null,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `useCitreaL1Fee` hook to fetch L1 fee data (l1DiffSize, l1FeeRate) via RPC
- Update `TxDetailsTxFee` to display total fee (L2 + L1) with breakdown
- Citrea L2 transactions have two fee components that were previously not shown correctly

## Changes

- `lib/web3/useCitreaL1Fee.ts` - New hook to fetch and calculate L1 fee
- `ui/tx/details/TxDetailsTxFee.tsx` - Updated to show total fee with L2/L1 breakdown

## Test plan

- [ ] View a transaction on the explorer
- [ ] Verify total fee shows L2 execution fee + L1 data fee
- [ ] Verify fee breakdown shows both components when L1 fee exists