### PR TITLE
Fix contract code not loading without tab query parameter

### DIFF
--- a/ui/address/AddressContract.tsx
+++ b/ui/address/AddressContract.tsx
@@ -26,18 +26,11 @@ interface Props {
 }
 
 const AddressContract = ({ addressData, isLoading = false, hasMudTab }: Props) => {
-  const [ isQueryEnabled, setIsQueryEnabled ] = React.useState(false);
   const [ autoVerificationStatus, setAutoVerificationStatus ] = React.useState<TContractAutoVerificationStatus | null>(null);
 
   const router = useRouter();
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
-  const handleChannelJoin = React.useCallback(() => {
-    setIsQueryEnabled(true);
-  }, []);
-  const handleChannelError = React.useCallback(() => {
-    setIsQueryEnabled(true);
-  }, []);
 
   const tab = getQueryParamString(router.query.tab);
   const isSocketEnabled = Boolean(addressData?.hash) && addressData?.is_contract && !isLoading && CONTRACT_TAB_IDS.concat('contract' as never).includes(tab);
@@ -45,13 +38,11 @@ const AddressContract = ({ addressData, isLoading = false, hasMudTab }: Props) =
   const channel = useSocketChannel({
     topic: `addresses:${ addressData?.hash?.toLowerCase() }`,
     isDisabled: !isSocketEnabled,
-    onJoin: handleChannelJoin,
-    onSocketError: handleChannelError,
   });
 
   const contractTabs = useContractTabs({
     addressData,
-    isEnabled: isQueryEnabled,
+    isEnabled: true,
     hasMudTab,
     channel,
   });


### PR DESCRIPTION
## Problem
Contract code doesn't render when visiting `/address/[hash]` without `?tab=contract` in URL, only showing skeleton loaders.

## Root Cause
Contract data fetch was gated by `isQueryEnabled` state, which only became true after WebSocket channel connected. The socket only connects when URL has `tab=contract`, so visiting without the param meant the query never enabled.

## Solution
Remove unnecessary coupling between socket connection and data fetch. Contract query now runs immediately when component mounts (i.e., when Contract tab is active). Socket still connects for real-time verification updates when needed.

## Changes
- Removed `isQueryEnabled` state and related callbacks
- Set `isEnabled: true` in `useContractTabs`
- Removed `onJoin`/`onSocketError` from socket channel config
