### PR TITLE
fix: add JUICE token to equity token addresses for mainnet

### DIFF
--- a/lib/token/stablecoin-addresses.generated.ts
+++ b/lib/token/stablecoin-addresses.generated.ts
@@ -45,6 +45,9 @@ export const VAULT_TOKEN_ADDRESSES: Record<string, ReadonlyArray<string>> = {
  * These tokens have a built-in price() function that returns the current price.
  */
 export const EQUITY_TOKEN_ADDRESSES: Record<string, ReadonlyArray<string>> = {
+  '4114': [
+    '0x2a36f2b204b46fd82653cd06d00c7ff757c99ae4',
+  ],
   '5115': [
     '0x7fa131991c8a7d8c21b11391c977fc7c4c8e0d5e',
   ],


### PR DESCRIPTION
## Summary
- Add JUICE token address (`0x2a36f2b204b46fd82653cd06d00c7ff757c99ae4`) to equity token configuration for chain ID 4114 (Citrea mainnet)
- Enables USD price display for JUICE token transfers via on-chain `price()` function lookup

## Context
JUICE token transfers on citreascan.com were not showing USD prices because the token address was not registered in the equity token list.

Example transaction: https://citreascan.com/tx/0xf63aa68b8be50e47bdb5990abfcb8a465500645d2ade50a8b860c74ab7ad715e

## Test plan
- [ ] Verify JUICE token transfers show USD price on citreascan.com after deployment
- [ ] Confirm `price()` function is callable on the JUICE contract