### PR TITLE
fix: add svJUSD vault token address for mainnet

### DIFF
--- a/lib/token/stablecoin-addresses.generated.ts
+++ b/lib/token/stablecoin-addresses.generated.ts
@@ -35,6 +35,9 @@ export const WRAPPED_NATIVE_ADDRESSES: Record<string, string> = {
  * The underlying asset is assumed to be a stablecoin worth $1.00.
  */
 export const VAULT_TOKEN_ADDRESSES: Record<string, ReadonlyArray<string>> = {
+  '4114': [
+    '0x1b70ae756b1089cc5948e4f8a2ad498df30e897d',
+  ],
   '5115': [
     '0x802a29bd29f02c8c477af5362f9ba88fae39cc7b',
   ],


### PR DESCRIPTION
## Summary
- Add svJUSD (Savings Vault JUSD) token address (`0x1b70ae756b1089cc5948e4f8a2ad498df30e897d`) to vault token configuration for chain ID 4114 (Citrea mainnet)
- Enables pricePerShare calculation (totalAssets/totalSupply) for svJUSD tokens, allowing USD price display

## Context
svJUSD vault token was only configured for testnet (5115) but not for mainnet (4114), causing missing USD prices on citreascan.com.

## Test plan
- [ ] Verify svJUSD token transfers show USD price on citreascan.com after deployment
- [ ] Confirm ERC-4626 vault functions (totalAssets, totalSupply) are callable on the contract