### PR TITLE
fix: add TAPFREAK equity token address for mainnet

### DIFF
--- a/lib/token/stablecoin-addresses.generated.ts
+++ b/lib/token/stablecoin-addresses.generated.ts
@@ -47,6 +47,7 @@ export const VAULT_TOKEN_ADDRESSES: Record<string, ReadonlyArray<string>> = {
 export const EQUITY_TOKEN_ADDRESSES: Record<string, ReadonlyArray<string>> = {
   '4114': [
     '0x2a36f2b204b46fd82653cd06d00c7ff757c99ae4',
+    '0xfaed2b431304426f9320761afdc698463b6fd8c7',
   ],
   '5115': [
     '0x7fa131991c8a7d8c21b11391c977fc7c4c8e0d5e',


### PR DESCRIPTION
## Summary
- Add TaprootFreak (TAPFREAK) token address (`0xfaed2b431304426f9320761afdc698463b6fd8c7`) to equity token configuration for chain ID 4114 (Citrea mainnet)
- Enables USD price display via on-chain `price()` function lookup

## Context
TAPFREAK is a JuiceSwap Launchpad token that uses the same equity token mechanism as JUICE, with a built-in `price()` function.

Launchpad: https://bapp.juiceswap.com/launchpad/0xfaed2b431304426f9320761afdc698463b6fd8c7

## Test plan
- [ ] Verify TAPFREAK token transfers show USD price on citreascan.com after deployment
- [ ] Confirm `price()` function is callable on the contract