### PR TITLE
fix: add missing /api/launchpad-token route to metadata dicts

### DIFF
--- a/lib/metadata/getPageOgType.ts
+++ b/lib/metadata/getPageOgType.ts
@@ -92,6 +92,7 @@ const OG_TYPE_DICT: Record<Route['pathname'], OGPageType> = {
   '/api/csrf': 'Regular page',
   '/api/healthz': 'Regular page',
   '/api/config': 'Regular page',
+  '/api/launchpad-token': 'Regular page',
 };
 
 export default function getPageOgType(pathname: Route['pathname']) {

--- a/lib/metadata/templates/description.ts
+++ b/lib/metadata/templates/description.ts
@@ -95,6 +95,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/api/csrf': DEFAULT_TEMPLATE,
   '/api/healthz': DEFAULT_TEMPLATE,
   '/api/config': DEFAULT_TEMPLATE,
+  '/api/launchpad-token': DEFAULT_TEMPLATE,
 };
 
 const TEMPLATE_MAP_ENHANCED: Partial<Record<Route['pathname'], string>> = {

--- a/lib/metadata/templates/title.ts
+++ b/lib/metadata/templates/title.ts
@@ -92,6 +92,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/api/csrf': '%network_name% node API CSRF token',
   '/api/healthz': '%network_name% node API health check',
   '/api/config': '%network_name% node API app config',
+  '/api/launchpad-token': '%network_name% node API launchpad token',
 };
 
 const TEMPLATE_MAP_ENHANCED: Partial<Record<Route['pathname'], string>> = {

--- a/lib/mixpanel/getPageType.ts
+++ b/lib/mixpanel/getPageType.ts
@@ -90,6 +90,7 @@ export const PAGE_TYPE_DICT: Record<Route['pathname'], string> = {
   '/api/csrf': 'Node API: CSRF token',
   '/api/healthz': 'Node API: Health check',
   '/api/config': 'Node API: App config',
+  '/api/launchpad-token': 'Node API: Launchpad token',
 };
 
 export default function getPageType(pathname: Route['pathname']) {


### PR DESCRIPTION
## Summary
- Adds the missing `/api/launchpad-token` route entry to all `Record<Route['pathname'], ...>` dictionaries
- Fixes the TypeScript build error that broke the DEV CI/CD pipeline

### Changed files
- `lib/metadata/getPageOgType.ts`
- `lib/metadata/templates/description.ts`
- `lib/metadata/templates/title.ts`
- `lib/mixpanel/getPageType.ts`

## Test plan
- [x] Docker build passes locally