### PR TITLE
Fix token price formatting to use 2 decimal places

### DIFF
--- a/ui/token/TokenDetails.tsx
+++ b/ui/token/TokenDetails.tsx
@@ -116,7 +116,7 @@ const TokenDetails = ({ tokenQuery }: Props) => {
           </DetailedInfo.ItemLabel>
           <DetailedInfo.ItemValue>
             <Skeleton loading={ tokenQuery.isPlaceholderData } display="inline-block">
-              <span>{ `$${ Number(exchangeRate).toLocaleString(undefined, { minimumSignificantDigits: 4 }) }` }</span>
+              <span>{ `$${ Number(exchangeRate).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }` }</span>
             </Skeleton>
           </DetailedInfo.ItemValue>
         </>


### PR DESCRIPTION

## Summary
- Fixed token price display from 3 decimal places to standard 2 decimal places (e.g., $1.00 instead of $1.000)

## Changes
- Updated TokenDetails.tsx to use minimumFractionDigits/maximumFractionDigits instead of minimumSignificantDigits

close #66 