### PR TITLE
Minor improvements UI

### DIFF
--- a/ui/shared/tx/TxTransferRow.tsx
+++ b/ui/shared/tx/TxTransferRow.tsx
@@ -52,8 +52,8 @@ const TxTransferRow = ({ data, isLoading }: Props) => {
       >
         Transfer
       </DetailedInfo.ItemLabel>
-      <DetailedInfo.ItemValue>
-        <Flex alignItems="center" flexWrap="wrap" gap={ 2 }>
+      <DetailedInfo.ItemValue minW={ 0 } overflow="hidden">
+        <Flex alignItems="center" flexWrap="wrap" gap={ 2 } minW={ 0 } maxW="100%">
           <span>from</span>
           <AddressEntity address={ fromAddress } isLoading={ isLoading } noIcon/>
           <span>to</span>


### PR DESCRIPTION
- Transfer row: The amount (e.g. 0.00029996 cBTC ($20.42)) is no longer shown in the Transfer row; it only shows “from CoinSwap to 0x…”. The value stays only in the Value row.

- Mobile: The address in the Transfer row is truncated like in “From”, so it no longer runs off the screen.