### PR TITLE
fix(ui): use internal from and to address for Transfer row

### DIFF
--- a/ui/shared/tx/TxTransferRow.tsx
+++ b/ui/shared/tx/TxTransferRow.tsx
@@ -2,6 +2,7 @@ import { Flex } from '@chakra-ui/react';
 import BigNumber from 'bignumber.js';
 import React from 'react';
 
+import type { AddressParam } from 'types/api/addressParams';
 import type { Transaction } from 'types/api/transaction';
 
 import * as DetailedInfo from 'ui/shared/DetailedInfo/DetailedInfo';
@@ -10,6 +11,7 @@ import AddressEntity from 'ui/shared/entities/address/AddressEntity';
 interface Props {
   data: Transaction;
   isLoading: boolean;
+  internalTransfer?: { from: AddressParam; to: AddressParam };
 }
 
 function getClaimToAddress(data: Transaction) {
@@ -22,7 +24,7 @@ function getClaimToAddress(data: Transaction) {
   return null;
 }
 
-const TxTransferRow = ({ data, isLoading }: Props) => {
+const TxTransferRow = ({ data, isLoading, internalTransfer }: Props) => {
   const flow = data.internal_value_flow;
   if (!flow || (flow.in === '0' && flow.out === '0')) return null;
 
@@ -32,15 +34,21 @@ const TxTransferRow = ({ data, isLoading }: Props) => {
   const netValue = BigNumber(flow.in).minus(BigNumber(flow.out)).abs();
   if (netValue.lte(0)) return null;
 
-  const isLockOrDeposit = method === 'lock' || method === 'deposit';
-  const fromAddress = isLockOrDeposit ? data.from : data.to;
-  let toAddress;
-  if (isLockOrDeposit) {
-    toAddress = data.to;
-  } else if (method === 'refund') {
-    toAddress = data.from;
+  let fromAddress: { hash: string } | undefined;
+  let toAddress: { hash: string } | undefined;
+  if (internalTransfer) {
+    fromAddress = internalTransfer.from;
+    toAddress = internalTransfer.to;
   } else {
-    toAddress = getClaimToAddress(data) || data.from;
+    const isLockOrDeposit = method === 'lock' || method === 'deposit';
+    fromAddress = isLockOrDeposit ? data.from : data.to ?? undefined;
+    if (isLockOrDeposit) {
+      toAddress = data.to ?? undefined;
+    } else if (method === 'refund') {
+      toAddress = data.from ?? undefined;
+    } else {
+      toAddress = getClaimToAddress(data) ?? data.from ?? undefined;
+    }
   }
   if (!fromAddress?.hash || !toAddress?.hash) return null;
 

--- a/ui/tx/details/TxInfo.tsx
+++ b/ui/tx/details/TxInfo.tsx
@@ -10,6 +10,7 @@ import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import type * as tac from '@blockscout/tac-operation-lifecycle-types';
+import type { InternalTransaction } from 'types/api/internalTransaction';
 import { SCROLL_L2_BLOCK_STATUSES } from 'types/api/scrollL2';
 import type { Transaction } from 'types/api/transaction';
 import { ZKEVM_L2_TX_STATUSES } from 'types/api/transaction';
@@ -83,6 +84,12 @@ interface Props {
 const externalTxFeature = config.features.externalTxs;
 const rollupFeature = config.features.rollup;
 
+function getInternalTransfer(items: Array<InternalTransaction> | undefined) {
+  const item = items?.find((tx) => tx.value !== '0') ?? items?.[0];
+  const to = item?.to ?? item?.created_contract;
+  return item?.from?.hash && to?.hash ? { from: item.from, to } : undefined;
+}
+
 const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
   const [ isExpanded, setIsExpanded ] = React.useState(false);
 
@@ -98,6 +105,20 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
     },
   });
 
+  const internalTxsQuery = useApiQuery('general:tx_internal_txs', {
+    pathParams: { hash: data?.hash ?? '' },
+    queryOptions: {
+      enabled: Boolean(
+        data?.hash &&
+        data?.internal_value_flow &&
+        (data.internal_value_flow.in !== '0' || data.internal_value_flow.out !== '0') &&
+        [ 'claim', 'claimbatch', 'refund', 'lock', 'deposit' ].includes((data?.method ?? '').toLowerCase()),
+      ),
+    },
+  });
+
+  const internalTransfer = getInternalTransfer(internalTxsQuery.data?.items);
+
   const handleCutLinkClick = React.useCallback(() => {
     setIsExpanded((flag) => !flag);
   }, []);
@@ -112,6 +133,7 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
 
   const flow = data.internal_value_flow;
   const hasInternalValueFlow = Boolean(flow && !(flow.in === '0' && flow.out === '0'));
+  const needInternalTransfer = hasInternalValueFlow && [ 'claim', 'claimbatch', 'refund', 'lock', 'deposit' ].includes((data.method ?? '').toLowerCase());
   const totalValue = hasInternalValueFlow ? BigNumber(flow!.in).minus(BigNumber(flow!.out)).abs().toString() : data.value;
 
   const addressFromTags = [
@@ -658,8 +680,8 @@ const TxInfo = ({ data, tacOperations, isLoading, socketStatus }: Props) => {
         </>
       ) }
 
-      { hasInternalValueFlow && data.internal_value_flow ? (
-        <TxTransferRow data={ data } isLoading={ isLoading }/>
+      { hasInternalValueFlow && data.internal_value_flow && (!needInternalTransfer || !internalTxsQuery.isLoading) ? (
+        <TxTransferRow data={ data } isLoading={ isLoading } internalTransfer={ internalTransfer }/>
       ) : null }
 
       <TxDetailsTxFee isLoading={ isLoading } data={ data }/>


### PR DESCRIPTION
## Summary

- **Use internal txns for Transfer row:** For deposit/lock/claim (etc.), the Transfer row now uses the internal txns API so it shows "from Bridge to 0x…" (internal transfer) instead of the top-level tx from/to.


# Before
<img width="938" height="464" alt="image" src="https://github.com/user-attachments/assets/042ad857-689d-420b-b264-0011470286b6" />


# After
<img width="948" height="473" alt="image" src="https://github.com/user-attachments/assets/c7126c4f-24b2-4d00-aac1-b355a046c251" />
