### PR TITLE
Switch CI/CD to self-hosted ARM64 runners

### DIFF
--- a/.github/workflows/frontend-dev.yml
+++ b/.github/workflows/frontend-dev.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to DEV
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, dfxdev]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,9 +21,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,17 +33,7 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
 
-      - name: Install cloudflared
+      - name: Deploy stacks
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
-          chmod +x /usr/local/bin/cloudflared
-
-      - name: Deploy to dfxdev
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          SSH_CMD="ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ProxyCommand=\"cloudflared access ssh --hostname %h\" dfxdev@ssh-dfxdev.dfxserve.com"
-          eval $SSH_CMD cs-testnet-frontend
-          eval $SSH_CMD cs-mainnet-frontend
-          rm ~/.ssh/deploy_key
+          cs-testnet-frontend
+          cs-mainnet-frontend

--- a/.github/workflows/frontend-prd.yml
+++ b/.github/workflows/frontend-prd.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to PRD
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, dfxprd]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,9 +21,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,17 +33,7 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
 
-      - name: Install cloudflared
+      - name: Deploy stacks
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
-          chmod +x /usr/local/bin/cloudflared
-
-      - name: Deploy to dfxprd
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DFXPRD_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          SSH_CMD="ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ProxyCommand=\"cloudflared access ssh --hostname %h\" dfxprd@ssh-dfxprd.dfxserve.com"
-          eval $SSH_CMD cs-testnet-frontend
-          eval $SSH_CMD cs-mainnet-frontend
-          rm ~/.ssh/deploy_key
+          cs-testnet-frontend
+          cs-mainnet-frontend


### PR DESCRIPTION
## Summary
- Build Docker images natively on dfxdev/dfxprd instead of QEMU emulation on ubuntu-latest
- QEMU builds took 90+ min or hung entirely (current PRD run stuck for 3+ hours)
- Deploy locally since the runner is already on the target server — removes cloudflared/SSH overhead

## Test plan
- [ ] Merge to develop, verify DEV build completes in minutes instead of 90 min
- [ ] Merge to main, verify PRD build + deploy succeeds