### PR TITLE
Remove internal hostnames from public workflows

### DIFF
--- a/.github/workflows/frontend-dev.yml
+++ b/.github/workflows/frontend-dev.yml
@@ -41,14 +41,13 @@ jobs:
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key \
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
             ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             cs-testnet-frontend
-          ssh -i ~/.ssh/deploy_key \
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
             ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             cs-mainnet-frontend

--- a/.github/workflows/frontend-dev.yml
+++ b/.github/workflows/frontend-dev.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to DEV
-    runs-on: [self-hosted, dfxdev]
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +33,22 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
 
-      - name: Deploy stacks
+      - name: Install cloudflared
         run: |
-          cs-testnet-frontend
-          cs-mainnet-frontend
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            cs-testnet-frontend
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            cs-mainnet-frontend

--- a/.github/workflows/frontend-prd.yml
+++ b/.github/workflows/frontend-prd.yml
@@ -41,14 +41,13 @@ jobs:
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DFXPRD_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key \
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
             ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
             cs-testnet-frontend
-          ssh -i ~/.ssh/deploy_key \
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
             ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
             cs-mainnet-frontend

--- a/.github/workflows/frontend-prd.yml
+++ b/.github/workflows/frontend-prd.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to PRD
-    runs-on: [self-hosted, dfxprd]
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +33,22 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
 
-      - name: Deploy stacks
+      - name: Install cloudflared
         run: |
-          cs-testnet-frontend
-          cs-mainnet-frontend
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            cs-testnet-frontend
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            cs-mainnet-frontend


### PR DESCRIPTION
## Summary
- Replace `[self-hosted, dfxdev/dfxprd]` with `ubuntu-24.04-arm` (GitHub-hosted ARM64 runner)
- Move all deploy targets (hostnames, users, SSH keys) to repo secrets
- Follows the same pattern as d-EURO public repos

## Required secrets
Before merging, these secrets must be configured in the repo:
- `DEPLOY_DEV_SSH_KEY`, `DEPLOY_DEV_SSH_KNOWN_HOSTS`, `DEPLOY_DEV_HOST`, `DEPLOY_DEV_USER`
- `DEPLOY_PRD_SSH_KEY`, `DEPLOY_PRD_SSH_KNOWN_HOSTS`, `DEPLOY_PRD_HOST`, `DEPLOY_PRD_USER`

## Test plan
- [ ] Configure secrets
- [ ] Merge to develop, verify DEV build + deploy
- [ ] Merge to main, verify PRD build + deploy