### PR TITLE
Fix API_HOST pointing to frontend instead of API subdomain

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -6,7 +6,7 @@ NEXT_PUBLIC_APP_HOST=dev.testnet.citreascan.com
 NEXT_PUBLIC_APP_PROTOCOL=https
 
 # Instance ENVs
-NEXT_PUBLIC_API_HOST=dev.testnet.citreascan.com
+NEXT_PUBLIC_API_HOST=dev.api.testnet.citreascan.com
 NEXT_PUBLIC_API_PROTOCOL=https
 
 NEXT_PUBLIC_NETWORK_RPC_URL=https://dev.rpc.testnet.citreascan.com

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ NEXT_PUBLIC_NETWORK_RPC_URL=https://dev.rpc.testnet.citreascan.com/
 # API Configuration
 # ===========================================
 NEXT_PUBLIC_API_BASE_PATH=
-NEXT_PUBLIC_API_HOST=dev.testnet.citreascan.com
+NEXT_PUBLIC_API_HOST=dev.api.testnet.citreascan.com
 NEXT_PUBLIC_API_PORT=
 NEXT_PUBLIC_API_PROTOCOL=https
 

--- a/.env.local
+++ b/.env.local
@@ -6,7 +6,7 @@ NEXT_PUBLIC_APP_ENV=development
 NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
 
 # Instance ENVs
-NEXT_PUBLIC_API_HOST=citreascan.com
+NEXT_PUBLIC_API_HOST=api.citreascan.com
 NEXT_PUBLIC_API_PROTOCOL=https
 
 NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.citreascan.com
@@ -24,7 +24,7 @@ NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 
 # CitreaScan branding (no Blockscout attribution)
 NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE=false
-NEXT_PUBLIC_OG_DESCRIPTION=Explore the Citrea Testnet blockchain with CitreaScan. Track transactions, verify contracts, analyze addresses, and access complete blockchain data and APIs.
+NEXT_PUBLIC_OG_DESCRIPTION=Explore the Citrea blockchain with CitreaScan. Track transactions, verify contracts, analyze addresses, and access complete blockchain data and APIs.
 NEXT_PUBLIC_OG_IMAGE_URL=file://public/static/og_image.png
 
 NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER=blockscout

--- a/.env.prd
+++ b/.env.prd
@@ -6,7 +6,7 @@ NEXT_PUBLIC_APP_HOST=citreascan.com
 NEXT_PUBLIC_APP_PROTOCOL=https
 
 # Instance ENVs
-NEXT_PUBLIC_API_HOST=citreascan.com
+NEXT_PUBLIC_API_HOST=api.citreascan.com
 NEXT_PUBLIC_API_PROTOCOL=https
 
 NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.citreascan.com


### PR DESCRIPTION
## Summary
- Fix `NEXT_PUBLIC_API_HOST` in all env files — was pointing to frontend domain instead of `api.*` subdomain
- Fix `OG_DESCRIPTION` in `.env.local` saying "Testnet" despite being mainnet config

## Changed files
- `.env.prd`: `citreascan.com` → `api.citreascan.com`
- `.env.local`: `citreascan.com` → `api.citreascan.com` + OG fix
- `.env.dev`: `dev.testnet.citreascan.com` → `dev.api.testnet.citreascan.com`
- `.env.example`: `dev.testnet.citreascan.com` → `dev.api.testnet.citreascan.com`

## Context
These env files are not used at runtime (docker-compose environment overrides them), but they serve as documentation and local dev defaults. The bug existed since the initial commit.